### PR TITLE
Added C# language support

### DIFF
--- a/app.js
+++ b/app.js
@@ -13,7 +13,7 @@ var router = express.Router();
 /**
  * Config
  */
-var supportedFormats = ['json', 'php', 'python', 'ruby'];
+var supportedFormats = ['json', 'php', 'python', 'ruby', 'csharp'];
 var datasets = {
   'states': 'U.S. States',
   'canadian-provinces': 'Canadian Provinces',

--- a/lib/converter.js
+++ b/lib/converter.js
@@ -7,6 +7,16 @@ function jsonToLang(json, lang, level) {
   var indentationLevel = level || 0;
   var dataFormatted = '';
   var formatMap = {
+    csharp: {
+      fileStart: "",
+      variable: "var data = ",
+      hashStart: "new Hashtable {",
+      hashEnd: "}",
+      hashRow: "{ \"%s\", %s }",
+      hashRowEnd: ",\n",
+      indent: "    ",
+      lineEnd: ";"
+    },
     php: {
       fileStart: "<?php\n",
       variable: "$data = ",
@@ -49,7 +59,17 @@ function jsonToLang(json, lang, level) {
     if (valueType == "array" || valueType == "object") {
       value = jsonToLang(value, lang, indentationLevel+1);
     } else if (valueType == "string") {
-      value = "'" + value + "'";
+      // Certain languages require double quotes for values
+      switch(lang)
+      {
+        case 'csharp':
+          value = "\"" + value + "\"";
+          break;
+
+        default:
+          value = "'" + value + "'";
+          break;
+      }
     }
 
     return value;

--- a/lib/converter.js
+++ b/lib/converter.js
@@ -22,7 +22,7 @@ function jsonToLang(json, lang, level) {
       variable: "$data = ",
       hashStart: "[",
       hashEnd: "]",
-      hashRow: "'%s' => %s",
+      hashRow: "\"%s\" => %s",
       hashRowEnd: ",\n",
       indent: "    ",
       lineEnd: ";"
@@ -32,7 +32,7 @@ function jsonToLang(json, lang, level) {
       variable: "data = ",
       hashStart: "{",
       hashEnd: "}",
-      hashRow: "'%s' : %s",
+      hashRow: "\"%s\" : %s",
       hashRowEnd: ",\n",
       indent: "    ",
       lineEnd: ""
@@ -59,17 +59,7 @@ function jsonToLang(json, lang, level) {
     if (valueType == "array" || valueType == "object") {
       value = jsonToLang(value, lang, indentationLevel+1);
     } else if (valueType == "string") {
-      // Certain languages require double quotes for values
-      switch(lang)
-      {
-        case 'csharp':
-          value = "\"" + value + "\"";
-          break;
-
-        default:
-          value = "'" + value + "'";
-          break;
-      }
+      value = "\"" + value + "\"";
     }
 
     return value;


### PR DESCRIPTION
Added a `formatMap` entry for the C# syntax of a `Hashtable`. I chose this over the more common generic Dictionary because additional refactoring would need to be done to account for the types and I didn’t feel it would be worth it.

I also modified the `jsonToLang()` function to account for double quotes in C# vs singles quotes in the existing languages implemented.

I wasn't sure of the order you would like the `supportedFormats` to be in, so I just tacked C# on to the end. They were in alphabetical, but I will leave that up to you.

I tested all of the rendered output in a C# application and all worked as expected.

Any feedback appreciated.
