### PR TITLE
Fixed python formatting to conform with PEP8

### DIFF
--- a/lib/converter.js
+++ b/lib/converter.js
@@ -32,7 +32,7 @@ function jsonToLang(json, lang, level) {
       variable: "data = ",
       hashStart: "{",
       hashEnd: "}",
-      hashRow: "\"%s\" : %s",
+      hashRow: "\"%s\": %s",
       hashRowEnd: ",\n",
       indent: "    ",
       lineEnd: ""


### PR DESCRIPTION
Dictionaries should not have a space between the key and the colon.

Based on https://www.python.org/dev/peps/pep-0008/. 
