### PR TITLE
added Dart language

### DIFF
--- a/app.js
+++ b/app.js
@@ -19,7 +19,8 @@ var supportedFormats = {
   'python': 'Python',
   'ruby': 'Ruby',
   'csharp': 'C#',
-  'lua': 'Lua'
+  'lua': 'Lua',
+  'dart': 'Dart'
 };
 var datasets = {
   'states': 'U.S. States',

--- a/lib/converter.js
+++ b/lib/converter.js
@@ -56,6 +56,16 @@ function jsonToLang(json, lang, level) {
       hashRowEnd: ",\n",
       indent: "    ",
       lineEnd: ""
+    },
+    dart: {
+      fileStart: "",
+      variable: "var data = ",
+      hashStart: "{",
+      hashEnd: "}",
+      hashRow: "\"%s\": %s",
+      hashRowEnd: ",\n",
+      indent: "    ",
+      lineEnd: ";"
     }
   };
 
@@ -82,7 +92,7 @@ function jsonToLang(json, lang, level) {
       break;
 
     case 'javascript':
-      dataFormatted = 'var data = ' + JSON.stringify(json, null, 4);
+      dataFormatted = 'var data = ' + JSON.stringify(json, null, 4) + ";";
       break;
 
     default:

--- a/public/assets/css/main.css
+++ b/public/assets/css/main.css
@@ -62,6 +62,12 @@ textarea.code {
   color: #eee;
   background-color: #000080;
 }
+.dataset-lang label.dart {
+  background-color: #55DDCA;
+}
+.dataset-lang label.dart.active {
+  background-color: #00D2B8;
+}
 
 
 .dataset-result {


### PR DESCRIPTION
also added semicolon to Javascript formatter. JS doesn't require it, but JSLint will throw a lint error for it and it's best to end declarations in `;` (semicolon wars aside).

A note on the Dart. While I changed the css to use the official colors from their site for the Dart tab, the PrismJS that is part of the repo now wasn't compiled with Dart support. Consequently, you get no syntax highlights for Dart and a constant "Formatting..." label. I will leave it to @vlucas to bring in a new PrismJS for the repo.

(also, I am working on replacing PrismJS with HighlightJS)
