### PR TITLE
added semicolon to JS results

### DIFF
--- a/lib/converter.js
+++ b/lib/converter.js
@@ -82,7 +82,7 @@ function jsonToLang(json, lang, level) {
       break;
 
     case 'javascript':
-      dataFormatted = 'var data = ' + JSON.stringify(json, null, 4);
+      dataFormatted = 'var data = ' + JSON.stringify(json, null, 4) + ";";
       break;
 
     default:


### PR DESCRIPTION
makes jslint happy and is pretty correct for js notwithstanding the semicolon haters
