### PR TITLE
Why no Perl? ;-)

### DIFF
--- a/app.js
+++ b/app.js
@@ -19,7 +19,8 @@ var supportedFormats = {
   'python': 'Python',
   'ruby': 'Ruby',
   'csharp': 'C#',
-  'lua': 'Lua'
+  'lua': 'Lua',
+  'perl': 'Perl'
 };
 var datasets = {
   'states': 'U.S. States',

--- a/lib/converter.js
+++ b/lib/converter.js
@@ -56,6 +56,16 @@ function jsonToLang(json, lang, level) {
       hashRowEnd: ",\n",
       indent: "    ",
       lineEnd: ""
+    },
+    perl: {
+      fileStart: "",
+      variable: "%data = ",
+      hashStart: "(", 
+      hashEnd: ")",
+      hashRow: "\"%s\": %s",
+      hashRowEnd: ",\n",
+      indent: "    ",
+      lineEnd: ""  
     }
   };
 

--- a/lib/converter.js
+++ b/lib/converter.js
@@ -59,13 +59,13 @@ function jsonToLang(json, lang, level) {
     },
     perl: {
       fileStart: "",
-      variable: "%data = ",
+      variable: "my %data = ",
       hashStart: "(", 
       hashEnd: ")",
-      hashRow: "\"%s\": %s",
+      hashRow: "\"%s\" => %s",
       hashRowEnd: ",\n",
       indent: "    ",
-      lineEnd: ""  
+      lineEnd: ";"  
     }
   };
 


### PR DESCRIPTION
```
#!/usr/bin/env perl

# Not sure which data layout you want for perl, so I've picked one. 
# As you can see from the following script, there are other ways to represent the same, (or similar data) in Perl.

my %data = ( 'test', this, 'antoher', that);
my %data_hash = ( "can", "be", "like", "this");
my %a_hash = ( "can" => "also", "be" => "like this");
my $also = { "another" => "type", "that" => "also works but isn't the same."};

use Data::Dumper;
print Dumper(\%data);
print Dumper(\%data_hash);
print Dumper(\%a_hash);
print Dumper($also);
```
